### PR TITLE
Clarify README.md and solve ansible warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ You need a machine with at least 20 GB free space with Debian 10 (bare-metal, vi
 ```
 sudo apt update
 sudo apt install -y python3 python3-pip
-pip3 install poetry
+sudo pip3 install poetry
 poetry install
 poetry shell
 ```
@@ -25,7 +25,8 @@ All other requirements will be installed by ansible-playbook.
 
 ## Prepare
 
-You need to copy the ISO image with VyOS to /tmp/vyos.iso before running ansible-playbook. Resulting images also will be located inside /tmp/ directory.
+You can copy the base ISO image with VyOS to ./build/vyos.iso before running ansible-playbook, or specify its location with the iso_local variable. The latest rolling build will be downloaded by the playbook.
+Resulting images also will be located inside ./build/ directory.
 
 ## Supported Platforms
 

--- a/hosts
+++ b/hosts
@@ -10,8 +10,8 @@ localhost
 [hyperv]
 localhost
 
-[vagrant-libvirt]
+[vagrant_libvirt]
 localhost
 
-[vagrant-virtualbox]
+[vagrant_virtualbox]
 localhost

--- a/roles/install-custom-packages/tasks/main.yml
+++ b/roles/install-custom-packages/tasks/main.yml
@@ -31,7 +31,6 @@
   become: true
   command: chroot {{ vyos_install_root }} apt-get -t {{ vyos_branch | default('current') }} install -y --no-install-recommends {{ lookup('file', 'files/custom_packages_list.txt') }}
 - name: Install custom packages from deb files
-  command:
   become: true
   command: chroot {{ vyos_install_root }} dpkg -i --force-depends /tmp/custom_debs/{{ item | basename }}
   with_fileglob: "{{ vyos_install_root }}/tmp/custom_debs/*.deb"

--- a/vagrant-libvirt.yml
+++ b/vagrant-libvirt.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: vagrant-libvirt
+- hosts: vagrant_libvirt
   become: True
   gather_facts: False
   connection: local

--- a/vagrant-virtualbox.yml
+++ b/vagrant-virtualbox.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: vagrant-virtualbox
+- hosts: vagrant_virtualbox
   become: True
   gather_facts: False
   connection: local


### PR DESCRIPTION
Update README with the new ./build/ location instead of /tmp and fix the group names and empty command that ansible warns about