### PR TITLE
remove become

### DIFF
--- a/roles/install-open-vmdk/tasks/main.yml
+++ b/roles/install-open-vmdk/tasks/main.yml
@@ -13,7 +13,6 @@
     dest: /tmp
   when: stat_result.stat.exists == False
 - name: Build open-vmdk
-  become: true
   make:
     chdir: /tmp/open-vmdk-master/vmdk
   when: stat_result.stat.exists == False


### PR DESCRIPTION
task 'Delete installation directory and archive' without become will fail if `make` was run priviledged